### PR TITLE
#3: Dodanie RECAPTCHA do formularza sprawdzania/usuwania użytkowników

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -40,6 +40,8 @@ twig:
     exception_controller: cantiga.controller.exception:showAction
     form_themes:
         - 'CantigaCoreBundle:layout:form-theme.html.twig'
+    globals:
+        recaptcha_api_url: https://www.google.com/recaptcha/api.js
 
 # Doctrine Configuration
 doctrine:

--- a/src/Cantiga/CoreBundle/Resources/views/Auth/register.html.twig
+++ b/src/Cantiga/CoreBundle/Resources/views/Auth/register.html.twig
@@ -1,5 +1,9 @@
 {% extends 'CantigaCoreBundle:layout:login-layout.html.twig' %}
 
+{% block javascripts_head %}
+	<script src="{{ recaptcha_api_url }}"></script>
+{% endblock %}
+
 {% block javascripts_inline %}
 	<script>
 	  $(function () {
@@ -56,6 +60,9 @@
 				<span class="glyphicon glyphicon-globe form-control-feedback"></span>
                 {{ form_errors(form.language) }}
 			</div>
+			<div class="form-group has-feedback">
+                {{ recaptcha.generateHtmlCode() | raw }}
+			</div>
 			<div class="row">
 				<div class="col-xs-1">
 					<div class="checkbox icheck" name="acceptRules">
@@ -70,7 +77,7 @@
 				</div>
 				<!-- /.col -->
 				<div class="col-xs-4">
-					<button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'Register' |trans }}</button>
+					<button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'Register' | trans }}</button>
 				</div>
 			</div>
 			<p class="login-box-msg"><a href="{{ path('cantiga_auth_terms') }}">{{ 'Terms of use' | trans }}</a> &bull;

--- a/src/WIO/EdkBundle/Form/EdkCheckRegistrationForm.php
+++ b/src/WIO/EdkBundle/Form/EdkCheckRegistrationForm.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WIO\EdkBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EdkCheckRegistrationForm extends AbstractType
+{
+	const TYPE_CHECK = 0;
+	const TYPE_REMOVE = 1;
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'translation_domain' => 'public'
+        ));
+    }
+	
+	public function buildForm(FormBuilderInterface $builder, array $options)
+	{
+		$builder
+            ->add('k', TextType::class, [
+                'label' => 'Your access code',
+                'required' => true,
+            ])
+            ->add('t', ChoiceType::class, [
+                'choices' => [
+                    'I want to check my status' => self::TYPE_CHECK,
+                    'I want to remove my request' => self::TYPE_REMOVE,
+                ],
+                'expanded' => true,
+                'label' => false,
+                'required' => true,
+            ])
+            ->add('execute', SubmitType::class, [
+                'label' => 'Execute',
+            ])
+        ;
+	}
+	
+	public function getName()
+    {
+		return 'edk_check_registration';
+	}
+}

--- a/src/WIO/EdkBundle/Resources/views/Public/check-registration.html.twig
+++ b/src/WIO/EdkBundle/Resources/views/Public/check-registration.html.twig
@@ -2,26 +2,23 @@
 
 {% block title %}{{ 'Check registration' | trans([], 'public') }} - {{ 'Extreme Way of the Cross' | trans([], 'public') }}{% endblock %}
 
+{% block javascripts_head %}
+	<script src="{{ recaptcha_api_url }}"></script>
+{% endblock %}
+
 {% block page_content %}
 <div>
 	<h2>{{ 'Check your registration' | trans([], 'public') }}</h2>
 	
 	<p>{{ 'CheckYourRegistrationText' | trans([], 'public') }}</p>
-	
-	<form method="get" action="{{ path('public_edk_check', { 'slug': slug }) }}">
+
+    {{ form_start(form) }}
+		{{ form_row(form.k) }}
+		{{ form_row(form.t) }}
 		<div class="form-group">
-			<label for="key">{{ 'Your access code' | trans([], 'public') }}</label>
-			<input type="text" name="k" class="form-control" id="key" />
+			{{ recaptcha.generateHtmlCode() | raw }}
 		</div>
-		<div class="form-group">
-			<label class="radio-inline">
-				<input type="radio" name="t" id="ch1" value="0" checked> {{ 'I want to check my status' | trans([], 'public') }}
-			</label>
-			<label class="radio-inline">
-				<input type="radio" name="t" id="ch1" value="1"> {{ 'I want to remove my request' | trans([], 'public') }}
-			</label>
-		</div>
-		<input class="btn btn-primary" type="submit" value="{{ 'Execute' | trans([], 'public') }}" />
-	</form>
+    	{{ form_row(form.execute) }}
+    {{ form_end(form) }}
 </div>
 {% endblock %}

--- a/src/WIO/EdkBundle/Resources/views/Public/message-form.html.twig
+++ b/src/WIO/EdkBundle/Resources/views/Public/message-form.html.twig
@@ -29,13 +29,11 @@
 		</div>
 	</div>
 	<div class="col-lg-12">
-		
-		
 		{{ form_row(form.save) }}
 	</div>
 	{{ form_end(form) }}
 {% endblock %}
 
 {% block javascripts_head %}
-<script src='https://www.google.com/recaptcha/api.js'></script>
+	<script src="{{ recaptcha_api_url }}"></script>
 {% endblock %}

--- a/src/WIO/EdkBundle/Resources/views/Public/registration-form.html.twig
+++ b/src/WIO/EdkBundle/Resources/views/Public/registration-form.html.twig
@@ -133,7 +133,7 @@
 {% endblock %}
 
 {% block javascripts_head %}
-    <script src='https://www.google.com/recaptcha/api.js'></script>
+    <script src="{{ recaptcha_api_url }}"></script>
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
#3: Nie jestem w stanie przetestować tego "pozytywnie", bo domena jest nie ta ale myślę, że jest to na tyle mała zmiana, że wystarczy wytestować ją po wdrożeniu.
Te zmiany wymagają zmian z #30, bo korzystają z jednej zmiennej globalnej zadeklarowanej dla Twiga.