### PR TITLE
#163 Add new verification fields

### DIFF
--- a/app/DoctrineMigrations/Version20200226200000.php
+++ b/app/DoctrineMigrations/Version20200226200000.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200226200000 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `cantiga_edk_routes`
+            ADD `pathCoordinates` text DEFAULT NULL AFTER `elevationCharacteristic`,
+            ADD `stations` text DEFAULT NULL AFTER `pathCoordinates`,
+            ADD `pathStartLat` decimal(18,9) DEFAULT NULL AFTER `stations`,
+            ADD `pathStartLng` decimal(18,9) DEFAULT NULL AFTER `pathStartLat`,
+            ADD `pathEndLat` decimal(18,9) DEFAULT NULL AFTER `pathStartLng`,
+            ADD `pathEndLng` decimal(18,9) DEFAULT NULL AFTER `pathEndLat`,
+            ADD `pathAvgLat` decimal(18,9) DEFAULT NULL AFTER `pathEndLng`,
+            ADD `pathAvgLng` decimal(18,9) DEFAULT NULL AFTER `pathAvgLat`');
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `cantiga_edk_routes`
+            DROP COLUMN `pathCoordinates`,
+            DROP COLUMN `stations`,
+            DROP COLUMN `pathStartLat`,
+            DROP COLUMN `pathStartLng`,
+            DROP COLUMN `pathEndLat`,
+            DROP COLUMN `pathEndLng`,
+            DROP COLUMN `pathAvgLat`,
+            DROP COLUMN `pathAvgLng`');
+    }
+}

--- a/app/DoctrineMigrations/Version20200226200000.php
+++ b/app/DoctrineMigrations/Version20200226200000.php
@@ -19,7 +19,7 @@ class Version20200226200000 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE `cantiga_edk_routes`
-            ADD `pathCoordinates` text DEFAULT NULL AFTER `elevationCharacteristic`,
+            ADD `pathCoordinates` longtext DEFAULT NULL AFTER `elevationCharacteristic`,
             ADD `stations` text DEFAULT NULL AFTER `pathCoordinates`,
             ADD `pathStartLat` decimal(18,9) DEFAULT NULL AFTER `stations`,
             ADD `pathStartLng` decimal(18,9) DEFAULT NULL AFTER `pathStartLat`,

--- a/app/DoctrineMigrations/Version20200226200000.php
+++ b/app/DoctrineMigrations/Version20200226200000.php
@@ -27,7 +27,6 @@ class Version20200226200000 extends AbstractMigration
             ADD `pathEndLng` decimal(18,9) DEFAULT NULL AFTER `pathEndLat`,
             ADD `pathAvgLat` decimal(18,9) DEFAULT NULL AFTER `pathEndLng`,
             ADD `pathAvgLng` decimal(18,9) DEFAULT NULL AFTER `pathAvgLat`');
-
     }
 
     /**

--- a/app/DoctrineMigrations/Version20200306034354.php
+++ b/app/DoctrineMigrations/Version20200306034354.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200306034354 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `cantiga_edk_routes`
+            CHANGE `pathCoordinates` `pathCoordinates` mediumtext DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `cantiga_edk_routes`
+            CHANGE `pathCoordinates` `pathCoordinates` longtext DEFAULT NULL');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "ext-pdo": "*",
         "symfony/symfony": "3.1.8",
         "doctrine/dbal": "^2.5.4",
         "doctrine/doctrine-bundle": "~1.6",

--- a/src/WIO/EdkBundle/Controller/RouteController.php
+++ b/src/WIO/EdkBundle/Controller/RouteController.php
@@ -251,12 +251,14 @@ class RouteController extends WorkspaceController
                 $flashBag->add('alert', implode(' ', array_merge([$message], $result->getVerificationLogs())));
             }
         } catch (Exception $exception) {
-            $messages = [$this->trans('VerificationError', [], 'edk')];
+            $messages = [$this->trans('VerificationError', [], 'edk'), $exception->getMessage()];
             $previousException = $exception->getPrevious();
             if ($previousException instanceof RouteVerifierResultException) {
                 foreach ($previousException->getViolations() as $violation) {
                     $messages[] = $violation;
                 }
+            } elseif (isset($previousException)) {
+                $messages[] = $previousException->getMessage();
             }
             $flashBag->add('error', implode(' ', $messages));
         }

--- a/src/WIO/EdkBundle/Controller/RouteController.php
+++ b/src/WIO/EdkBundle/Controller/RouteController.php
@@ -229,6 +229,10 @@ class RouteController extends WorkspaceController
             $result = $routeVerifier->verify($route);
             $route
                 ->setElevationCharacteristic($result->getElevationCharacteristic())
+                ->setPathCoordinates($result->getPathCoordinates())
+                ->setStations($result->getStations())
+                ->setPathStart($result->getPathStart())
+                ->setPathEnd($result->getPathEnd())
                 ->setVerificationStatus($result->getVerificationStatus())
                 ->setRouteAscent($result->getRouteAscent())
                 ->setRouteLength($result->getRouteLength())

--- a/src/WIO/EdkBundle/Controller/RouteController.php
+++ b/src/WIO/EdkBundle/Controller/RouteController.php
@@ -40,11 +40,13 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use WIO\EdkBundle\Client\RouteVerifierClient;
 use WIO\EdkBundle\Entity\EdkRoute;
+use WIO\EdkBundle\Exception\RouteVerifierResultException;
 use WIO\EdkBundle\Form\EdkRouteForm;
 use WIO\EdkBundle\Form\AreaRoutesImportForm;
 use WIO\EdkBundle\EdkTexts;
@@ -221,6 +223,7 @@ class RouteController extends WorkspaceController
 
         /** @var SessionInterface $session */
         $session = $this->get('session');
+        /** @var FlashBagInterface $flashBag */
         $flashBag = $session->getFlashBag();
 
         try {
@@ -239,18 +242,23 @@ class RouteController extends WorkspaceController
                 ->setRouteType($result->getRouteType())
             ;
             if ($result->isValid()) {
+                $message = $this->trans('VerificationSuccessful', [], 'edk');
                 $routeRepository->approve($route, $user, true);
-                $flashBag->add('info', implode(' ', array_merge([
-                    $this->trans('VerificationSuccessful', [], 'edk'),
-                ], $result->getVerificationLogs())));
+                $flashBag->add('info', implode(' ', array_merge([$message], $result->getVerificationLogs())));
             } else {
+                $message = $this->trans('VerificationFailed', [], 'edk');
                 $routeRepository->revoke($route, $user, true);
-                $flashBag->add('info', implode(' ', array_merge([
-                    $this->trans('VerificationFailed', [], 'edk'),
-                ], $result->getVerificationLogs())));
+                $flashBag->add('alert', implode(' ', array_merge([$message], $result->getVerificationLogs())));
             }
         } catch (Exception $exception) {
-            $flashBag->add('error', $this->trans('VerificationError', [], 'edk'));
+            $messages = [$this->trans('VerificationError', [], 'edk')];
+            $previousException = $exception->getPrevious();
+            if ($previousException instanceof RouteVerifierResultException) {
+                foreach ($previousException->getViolations() as $violation) {
+                    $messages[] = $violation;
+                }
+            }
+            $flashBag->add('error', implode(' ', $messages));
         }
 
         return $this->redirectToRoute('edk_route_info', [

--- a/src/WIO/EdkBundle/Entity/EdkRoute.php
+++ b/src/WIO/EdkBundle/Entity/EdkRoute.php
@@ -121,19 +121,19 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 	private $mapFileUpload;
 	/** @var UploadedFile */
 	private $gpsTrackFileUpload;
-    /** @var array|null */
+	/** @var array|null */
 	private $verificationStatus;
 	/** @var array|null */
 	private $elevationCharacteristic;
-    /** @var Coordinates[] */
+	/** @var Coordinates[] */
 	private $pathCoordinates = [];
-    /** @var IndexedCoordinates[] */
+	/** @var IndexedCoordinates[] */
 	private $stations = [];
 	/** @var Coordinates|null */
 	private $pathStart;
-    /** @var Coordinates|null */
+	/** @var Coordinates|null */
 	private $pathEnd;
-    /** @var Coordinates|null */
+	/** @var Coordinates|null */
 	private $pathAvg;
 	private $publicAccessSlug;
 	private $commentNum;
@@ -207,11 +207,11 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 		$item = new EdkRoute;
 		DataMappers::fromArray($item, $array, $prefix);
 		if (isset($array['pathStartLat']) && isset($array['pathStartLng'])) {
-            $item->setPathStart(new Coordinates((float) $array['pathStartLat'], (float) $array['pathStartLng']));
-        }
+			$item->setPathStart(new Coordinates((float) $array['pathStartLat'], (float) $array['pathStartLng']));
+		}
 		if (isset($array['pathEndLat']) && isset($array['pathEndLng'])) {
-            $item->setPathEnd(new Coordinates((float) $array['pathEndLat'], (float) $array['pathEndLng']));
-        }
+			$item->setPathEnd(new Coordinates((float) $array['pathEndLat'], (float) $array['pathEndLng']));
+		}
 		return $item;
 	}
 
@@ -466,7 +466,7 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 		return $this->gpsTrackFileUpload;
 	}
 
-    /** @return array|null */
+	/** @return array|null */
 	public function getVerificationStatus()
 	{
 		return $this->verificationStatus;
@@ -478,31 +478,31 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 		return $this->elevationCharacteristic;
 	}
 
-    /** @return Coordinates[] */
+	/** @return Coordinates[] */
 	public function getPathCoordinates()
 	{
 		return $this->pathCoordinates;
 	}
 
-    /** @return IndexedCoordinates[] */
+	/** @return IndexedCoordinates[] */
 	public function getStations()
 	{
 		return $this->stations;
 	}
 
-    /** @return Coordinates|null */
+	/** @return Coordinates|null */
 	public function getPathStart()
 	{
 		return $this->pathStart;
 	}
 
-    /** @return Coordinates|null */
+	/** @return Coordinates|null */
 	public function getPathEnd()
 	{
 		return $this->pathEnd;
 	}
 
-    /** @return Coordinates|null */
+	/** @return Coordinates|null */
 	public function getPathAvg()
 	{
 		return $this->pathAvg;
@@ -824,43 +824,43 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 
 	public function setPathCoordinates($pathCoordinates)
 	{
-	    if (is_string($pathCoordinates)) {
-            $pathCoordinates = json_decode($pathCoordinates, true);
-        }
+		if (is_string($pathCoordinates)) {
+			$pathCoordinates = json_decode($pathCoordinates, true);
+		}
 		$this->pathCoordinates = is_array($pathCoordinates) ? array_map(function ($data) {
-            return $data instanceof Coordinates ? $data : Coordinates::createFromDb($data);
-        }, $pathCoordinates) : [];
+			return $data instanceof Coordinates ? $data : Coordinates::createFromDb($data);
+		}, $pathCoordinates) : [];
 		return $this;
 	}
 
 	public function setStations($stations)
 	{
-        if (is_string($stations)) {
-            $stations = json_decode($stations, true);
-        }
-        $this->stations = is_array($stations) ? array_map(function ($data) {
-            return $data instanceof IndexedCoordinates ? $data : IndexedCoordinates::createFromDb($data);
-        }, $stations) : [];
-        return $this;
+		if (is_string($stations)) {
+			$stations = json_decode($stations, true);
+		}
+		$this->stations = is_array($stations) ? array_map(function ($data) {
+			return $data instanceof IndexedCoordinates ? $data : IndexedCoordinates::createFromDb($data);
+		}, $stations) : [];
+		return $this;
 	}
 
-    public function setPathStart($pathStart)
-    {
-        $this->pathStart = $pathStart;
-        if (isset($this->pathStart) && isset($this->pathEnd)) {
-            $this->pathAvg = Coordinates::createAvg($this->pathStart, $this->pathEnd);
-        }
-        return $this;
-    }
+	public function setPathStart($pathStart)
+	{
+		$this->pathStart = $pathStart;
+		if (isset($this->pathStart) && isset($this->pathEnd)) {
+			$this->pathAvg = Coordinates::createAvg($this->pathStart, $this->pathEnd);
+		}
+		return $this;
+	}
 
-    public function setPathEnd($pathEnd)
-    {
-        $this->pathEnd = $pathEnd;
-        if (isset($this->pathStart) && isset($this->pathEnd)) {
-            $this->pathAvg = Coordinates::createAvg($this->pathStart, $this->pathEnd);
-        }
-        return $this;
-    }
+	public function setPathEnd($pathEnd)
+	{
+		$this->pathEnd = $pathEnd;
+		if (isset($this->pathStart) && isset($this->pathEnd)) {
+			$this->pathAvg = Coordinates::createAvg($this->pathStart, $this->pathEnd);
+		}
+		return $this;
+	}
 
 	public function setPublicAccessSlug($publicAccessSlug)
 	{
@@ -1335,7 +1335,7 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 			$this->gpsApprovedBy = $user->getId();
 
 			$pathAvg = isset($this->pathStart) && isset($this->pathEnd) ?
-                Coordinates::createAvg($this->pathStart, $this->pathEnd) : null;
+				Coordinates::createAvg($this->pathStart, $this->pathEnd) : null;
 			$conn->update(EdkTables::ROUTE_TBL,
 				[
 					'approved' => $this->approved,
@@ -1376,28 +1376,28 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 			$this->approvedAt = time();
 			$this->approvedBy = $user->getId();
 
-            $pathAvg = isset($this->pathStart) && isset($this->pathEnd) ?
-                Coordinates::createAvg($this->pathStart, $this->pathEnd) : null;
+			$pathAvg = isset($this->pathStart) && isset($this->pathEnd) ?
+				Coordinates::createAvg($this->pathStart, $this->pathEnd) : null;
 			$conn->update(EdkTables::ROUTE_TBL,
 				[
 					'approved' => $this->approved,
 					'approvedAt' => $this->approvedAt,
 					'approvedBy' => $this->approvedBy,
-                    'elevationCharacteristic' => isset($this->elevationCharacteristic) ?
-                        json_encode($this->elevationCharacteristic) : null,
-                    'pathCoordinates' => isset($this->pathCoordinates) ? json_encode($this->pathCoordinates) : null,
-                    'stations' => isset($this->stations) ? json_encode($this->stations) : null,
-                    'pathStartLat' => isset($this->pathStart) ? $this->pathStart->getLatitude() : null,
-                    'pathStartLng' => isset($this->pathStart) ? $this->pathStart->getLongitude() : null,
-                    'pathEndLat' => isset($this->pathEnd) ? $this->pathEnd->getLatitude() : null,
-                    'pathEndLng' => isset($this->pathEnd) ? $this->pathEnd->getLongitude() : null,
-                    'pathAvgLat' => isset($pathAvg) ? $pathAvg->getLatitude() : null,
-                    'pathAvgLng' => isset($pathAvg) ? $pathAvg->getLongitude() : null,
-                    'routeAscent' => $this->routeAscent,
-                    'routeLength' => $this->routeLength,
-                    'routeType' => $this->routeType,
-                    'verificationStatus' => isset($this->verificationStatus) ? json_encode($this->verificationStatus) :
-                        null,
+					'elevationCharacteristic' => isset($this->elevationCharacteristic) ?
+						json_encode($this->elevationCharacteristic) : null,
+					'pathCoordinates' => isset($this->pathCoordinates) ? json_encode($this->pathCoordinates) : null,
+					'stations' => isset($this->stations) ? json_encode($this->stations) : null,
+					'pathStartLat' => isset($this->pathStart) ? $this->pathStart->getLatitude() : null,
+					'pathStartLng' => isset($this->pathStart) ? $this->pathStart->getLongitude() : null,
+					'pathEndLat' => isset($this->pathEnd) ? $this->pathEnd->getLatitude() : null,
+					'pathEndLng' => isset($this->pathEnd) ? $this->pathEnd->getLongitude() : null,
+					'pathAvgLat' => isset($pathAvg) ? $pathAvg->getLatitude() : null,
+					'pathAvgLng' => isset($pathAvg) ? $pathAvg->getLongitude() : null,
+					'routeAscent' => $this->routeAscent,
+					'routeLength' => $this->routeLength,
+					'routeType' => $this->routeType,
+					'verificationStatus' => isset($this->verificationStatus) ? json_encode($this->verificationStatus) :
+						null,
 				],
 				[
 					'id' => $this->getId(),

--- a/src/WIO/EdkBundle/Entity/EdkRoute.php
+++ b/src/WIO/EdkBundle/Entity/EdkRoute.php
@@ -206,6 +206,12 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 	{
 		$item = new EdkRoute;
 		DataMappers::fromArray($item, $array, $prefix);
+		if (isset($array['pathStartLat']) && isset($array['pathStartLng'])) {
+            $item->setPathStart(new Coordinates((float) $array['pathStartLat'], (float) $array['pathStartLng']));
+        }
+		if (isset($array['pathEndLat']) && isset($array['pathEndLng'])) {
+            $item->setPathEnd(new Coordinates((float) $array['pathEndLat'], (float) $array['pathEndLng']));
+        }
 		return $item;
 	}
 
@@ -1329,7 +1335,7 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 			$this->gpsApprovedBy = $user->getId();
 
 			$pathAvg = isset($this->pathStart) && isset($this->pathEnd) ?
-                Coordinates::createAvg($this->pathStart, $this->pathStart) : null;
+                Coordinates::createAvg($this->pathStart, $this->pathEnd) : null;
 			$conn->update(EdkTables::ROUTE_TBL,
 				[
 					'approved' => $this->approved,
@@ -1371,7 +1377,7 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 			$this->approvedBy = $user->getId();
 
             $pathAvg = isset($this->pathStart) && isset($this->pathEnd) ?
-                Coordinates::createAvg($this->pathStart, $this->pathStart) : null;
+                Coordinates::createAvg($this->pathStart, $this->pathEnd) : null;
 			$conn->update(EdkTables::ROUTE_TBL,
 				[
 					'approved' => $this->approved,

--- a/src/WIO/EdkBundle/Entity/EdkRoute.php
+++ b/src/WIO/EdkBundle/Entity/EdkRoute.php
@@ -819,7 +819,7 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 	public function setPathCoordinates($pathCoordinates)
 	{
 	    if (is_string($pathCoordinates)) {
-            $pathCoordinates = json_decode($pathCoordinates);
+            $pathCoordinates = json_decode($pathCoordinates, true);
         }
 		$this->pathCoordinates = is_array($pathCoordinates) ? array_map(function ($data) {
             return $data instanceof Coordinates ? $data : Coordinates::createFromDb($data);
@@ -830,7 +830,7 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 	public function setStations($stations)
 	{
         if (is_string($stations)) {
-            $stations = json_decode($stations);
+            $stations = json_decode($stations, true);
         }
         $this->stations = is_array($stations) ? array_map(function ($data) {
             return $data instanceof IndexedCoordinates ? $data : IndexedCoordinates::createFromDb($data);

--- a/src/WIO/EdkBundle/Exception/RouteVerifierResultException.php
+++ b/src/WIO/EdkBundle/Exception/RouteVerifierResultException.php
@@ -3,7 +3,34 @@
 namespace WIO\EdkBundle\Exception;
 
 use Cantiga\Metamodel\Exception\ModelException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Throwable;
 
 class RouteVerifierResultException extends ModelException
 {
+    /** @var ConstraintViolationListInterface */
+    private $violations;
+
+    /**
+     * Construct
+     *
+     * @param ConstraintViolationListInterface $violations violations
+     * @param int                              $code       code
+     * @param Throwable|null                   $previous   previous
+     */
+    public function __construct($violations, $code = 0, Throwable $previous = null)
+    {
+        parent::__construct('Constraint violations occurred.', $code, $previous);
+        $this->violations = $violations;
+    }
+
+    /**
+     * Get violations
+     *
+     * @return ConstraintViolationListInterface
+     */
+    public function getViolations()
+    {
+        return $this->violations;
+    }
 }

--- a/src/WIO/EdkBundle/Model/Coordinates.php
+++ b/src/WIO/EdkBundle/Model/Coordinates.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WIO\EdkBundle\Model;
+
+use JsonSerializable;
+
+class Coordinates implements JsonSerializable
+{
+    /** @var float */
+    private $latitude;
+
+    /** @var float */
+    private $longitude;
+
+    public function __construct(float $latitude, float $longitude)
+    {
+        $this->latitude = $latitude;
+        $this->longitude = $longitude;
+    }
+
+    public static function createFromDb(array $data)
+    {
+        return new self($data['lat'], $data['lng']);
+    }
+
+    public static function createAvg(...$list): self
+    {
+        $count = count($list);
+        if ($count === 0) {
+            return new self(0, 0);
+        }
+        $latitudeSum = 0;
+        $longitudeSum = 0;
+        /** @var Coordinates $coordinates */
+        foreach ($list as $coordinates) {
+            $latitudeSum += $coordinates->getLatitude();
+            $longitudeSum += $coordinates->getLongitude();
+        }
+        return new self($latitudeSum / $count, $longitudeSum / $count);
+    }
+
+    public function getLatitude(): float
+    {
+        return $this->latitude;
+    }
+
+    public function getLongitude(): float
+    {
+        return $this->longitude;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'lat' => $this->getLatitude(),
+            'lng' => $this->getLongitude(),
+        ];
+    }
+}

--- a/src/WIO/EdkBundle/Model/Coordinates.php
+++ b/src/WIO/EdkBundle/Model/Coordinates.php
@@ -20,7 +20,7 @@ class Coordinates implements JsonSerializable
 
     public static function createFromDb(array $data)
     {
-        return new self($data['lat'], $data['lng']);
+        return new self($data[0], $data[1]);
     }
 
     public static function createAvg(...$list): self
@@ -52,8 +52,8 @@ class Coordinates implements JsonSerializable
     public function jsonSerialize()
     {
         return [
-            'lat' => $this->getLatitude(),
-            'lng' => $this->getLongitude(),
+            $this->getLatitude(),
+            $this->getLongitude(),
         ];
     }
 }

--- a/src/WIO/EdkBundle/Model/IndexedCoordinates.php
+++ b/src/WIO/EdkBundle/Model/IndexedCoordinates.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WIO\EdkBundle\Model;
+
+class IndexedCoordinates extends Coordinates
+{
+    /** @var int */
+    private $index;
+
+    public function __construct(int $index, float $latitude, float $longitude)
+    {
+        $this->index = $index;
+        parent::__construct($latitude, $longitude);
+    }
+
+    public static function createFromDb(array $data)
+    {
+        return new self($data['index'], $data['lat'], $data['lng']);
+    }
+
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'index' => $this->getIndex(),
+            'lat' => $this->getLatitude(),
+            'lng' => $this->getLongitude(),
+        ];
+    }
+}

--- a/src/WIO/EdkBundle/Model/IndexedCoordinates.php
+++ b/src/WIO/EdkBundle/Model/IndexedCoordinates.php
@@ -15,7 +15,7 @@ class IndexedCoordinates extends Coordinates
 
     public static function createFromDb(array $data)
     {
-        return new self($data['index'], $data['lat'], $data['lng']);
+        return new self($data[0], $data[1], $data[2]);
     }
 
     public function getIndex(): int
@@ -26,9 +26,9 @@ class IndexedCoordinates extends Coordinates
     public function jsonSerialize()
     {
         return [
-            'index' => $this->getIndex(),
-            'lat' => $this->getLatitude(),
-            'lng' => $this->getLongitude(),
+            $this->getIndex(),
+            $this->getLatitude(),
+            $this->getLongitude(),
         ];
     }
 }

--- a/src/WIO/EdkBundle/Model/RouteVerifierResult.php
+++ b/src/WIO/EdkBundle/Model/RouteVerifierResult.php
@@ -175,9 +175,9 @@ class RouteVerifierResult
             return new IndexedCoordinates($data['index'], round($data['latitude'], 10), round($data['longitude'], 10));
         }, $body['routeCharacteristics']['stations']);
         $pathStart = $body['routeCharacteristics']['pathStart'];
-        $this->pathStart = new Coordinates($pathStart['latitude'], $pathStart['longitude']);
+        $this->pathStart = new Coordinates(round($pathStart['latitude'], 10), round($pathStart['longitude'], 10));
         $pathEnd = $body['routeCharacteristics']['pathEnd'];
-        $this->pathEnd = new Coordinates($pathEnd['latitude'], $pathEnd['longitude']);
+        $this->pathEnd = new Coordinates(round($pathEnd['latitude'], 10), round($pathEnd['longitude'], 10));
     }
 
     public function isValid(): bool

--- a/src/WIO/EdkBundle/Model/RouteVerifierResult.php
+++ b/src/WIO/EdkBundle/Model/RouteVerifierResult.php
@@ -20,6 +20,18 @@ class RouteVerifierResult
     /** @var array */
     private $elevationCharacteristic;
 
+    /** @var Coordinates[] */
+    private $pathCoordinates;
+
+    /** @var IndexedCoordinates[] */
+    private $stations;
+
+    /** @var Coordinates */
+    private $pathStart;
+
+    /** @var Coordinates */
+    private $pathEnd;
+
     public function __construct(array $body)
     {
         $statusItemsByValues = [
@@ -45,6 +57,33 @@ class RouteVerifierResult
                                 new Assert\Collection([
                                     'distance' => new LocalAssert\Type('number'),
                                     'elevation' => new LocalAssert\Type('number'),
+                                ]),
+                            ]),
+                        ],
+                        'pathCoordinates' => [
+                            new Assert\Type('array'),
+                            new Assert\All([
+                                new Assert\Collection([
+                                    'latitude' => new LocalAssert\Type('number'),
+                                    'longitude' => new LocalAssert\Type('number'),
+                                ]),
+                            ]),
+                        ],
+                        'pathEnd' => new Assert\Collection([
+                            'latitude' => new LocalAssert\Type('number'),
+                            'longitude' => new LocalAssert\Type('number'),
+                        ]),
+                        'pathStart' => new Assert\Collection([
+                            'latitude' => new LocalAssert\Type('number'),
+                            'longitude' => new LocalAssert\Type('number'),
+                        ]),
+                        'stations' => [
+                            new Assert\Type('array'),
+                            new Assert\All([
+                                new Assert\Collection([
+                                    'index' => new LocalAssert\Type('number'),
+                                    'latitude' => new LocalAssert\Type('number'),
+                                    'longitude' => new LocalAssert\Type('number'),
                                 ]),
                             ]),
                         ],
@@ -90,6 +129,16 @@ class RouteVerifierResult
         }, ARRAY_FILTER_USE_KEY);
         $this->verificationLogs = $body['verificationStatus']['logs'];
         $this->elevationCharacteristic = $body['routeCharacteristics']['elevationCharacteristics'];
+        $this->pathCoordinates = array_map(function ($data) {
+            return new Coordinates($data['latitude'], $data['longitude']);
+        }, $body['routeCharacteristics']['pathCoordinates']);
+        $this->stations = array_map(function ($data) {
+            return new IndexedCoordinates($data['index'], $data['latitude'], $data['longitude']);
+        }, $body['routeCharacteristics']['stations']);
+        $pathStart = $body['routeCharacteristics']['pathStart'];
+        $this->pathStart = new Coordinates($pathStart['latitude'], $pathStart['longitude']);
+        $pathEnd = $body['routeCharacteristics']['pathEnd'];
+        $this->pathEnd = new Coordinates($pathEnd['latitude'], $pathEnd['longitude']);
     }
 
     public function isValid(): bool
@@ -116,6 +165,28 @@ class RouteVerifierResult
     public function getElevationCharacteristic(): array
     {
         return $this->elevationCharacteristic;
+    }
+
+    /** @return Coordinates[] */
+    public function getPathCoordinates(): array
+    {
+        return $this->pathCoordinates;
+    }
+
+    /** @return IndexedCoordinates[] */
+    public function getStations(): array
+    {
+        return $this->stations;
+    }
+
+    public function getPathStart(): Coordinates
+    {
+        return $this->pathStart;
+    }
+
+    public function getPathEnd(): Coordinates
+    {
+        return $this->pathEnd;
     }
 
     public function getRouteAscent(): float

--- a/src/WIO/EdkBundle/Model/RouteVerifierResult.php
+++ b/src/WIO/EdkBundle/Model/RouteVerifierResult.php
@@ -15,10 +15,10 @@ class RouteVerifierResult
     const MAX_ELEVATION_CHARACTERISTICS_NUMBER = 1000; // ~ 65535 / 65
 
     /** @var int */
-    const MAX_PATH_COORDINATES_NUMBER = 100000; // ~ 16777215 / 35
+    const MAX_PATH_COORDINATES_NUMBER = 100000; // ~ 16777215 / 30
 
     /** @var int */
-    const MAX_STATIONS_NUMBER = 1600; // ~ 65535 / 40
+    const MAX_STATIONS_NUMBER = 1800; // ~ 65535 / 35
 
     /** @var array */
     private $verificationStatus;
@@ -169,15 +169,15 @@ class RouteVerifierResult
             return ['distance' => round($data['distance'], 20), 'elevation' => round($data['elevation'], 20)];
         }, $body['routeCharacteristics']['elevationCharacteristics']);
         $this->pathCoordinates = array_map(function ($data) {
-            return new Coordinates(round($data['latitude'], 10), round($data['longitude'], 10));
+            return new Coordinates(round($data['latitude'], 9), round($data['longitude'], 9));
         }, $body['routeCharacteristics']['pathCoordinates']);
         $this->stations = array_map(function ($data) {
-            return new IndexedCoordinates($data['index'], round($data['latitude'], 10), round($data['longitude'], 10));
+            return new IndexedCoordinates($data['index'], round($data['latitude'], 9), round($data['longitude'], 9));
         }, $body['routeCharacteristics']['stations']);
         $pathStart = $body['routeCharacteristics']['pathStart'];
-        $this->pathStart = new Coordinates(round($pathStart['latitude'], 10), round($pathStart['longitude'], 10));
+        $this->pathStart = new Coordinates(round($pathStart['latitude'], 9), round($pathStart['longitude'], 9));
         $pathEnd = $body['routeCharacteristics']['pathEnd'];
-        $this->pathEnd = new Coordinates(round($pathEnd['latitude'], 10), round($pathEnd['longitude'], 10));
+        $this->pathEnd = new Coordinates(round($pathEnd['latitude'], 9), round($pathEnd['longitude'], 9));
     }
 
     public function isValid(): bool

--- a/src/WIO/EdkBundle/Model/RouteVerifierResult.php
+++ b/src/WIO/EdkBundle/Model/RouteVerifierResult.php
@@ -64,26 +64,38 @@ class RouteVerifierResult
                             new Assert\Type('array'),
                             new Assert\All([
                                 new Assert\Collection([
-                                    'latitude' => new LocalAssert\Type('number'),
-                                    'longitude' => new LocalAssert\Type('number'),
+                                    'allowExtraFields' => true,
+                                    'fields' => [
+                                        'latitude' => new LocalAssert\Type('number'),
+                                        'longitude' => new LocalAssert\Type('number'),
+                                    ],
                                 ]),
                             ]),
                         ],
                         'pathEnd' => new Assert\Collection([
-                            'latitude' => new LocalAssert\Type('number'),
-                            'longitude' => new LocalAssert\Type('number'),
+                            'allowExtraFields' => true,
+                            'fields' => [
+                                'latitude' => new LocalAssert\Type('number'),
+                                'longitude' => new LocalAssert\Type('number'),
+                            ],
                         ]),
                         'pathStart' => new Assert\Collection([
-                            'latitude' => new LocalAssert\Type('number'),
-                            'longitude' => new LocalAssert\Type('number'),
+                            'allowExtraFields' => true,
+                            'fields' => [
+                                'latitude' => new LocalAssert\Type('number'),
+                                'longitude' => new LocalAssert\Type('number'),
+                            ],
                         ]),
                         'stations' => [
                             new Assert\Type('array'),
                             new Assert\All([
                                 new Assert\Collection([
-                                    'index' => new LocalAssert\Type('number'),
-                                    'latitude' => new LocalAssert\Type('number'),
-                                    'longitude' => new LocalAssert\Type('number'),
+                                    'allowExtraFields' => true,
+                                    'fields' => [
+                                        'index' => new LocalAssert\Type('number'),
+                                        'latitude' => new LocalAssert\Type('number'),
+                                        'longitude' => new LocalAssert\Type('number'),
+                                    ],
                                 ]),
                             ]),
                         ],

--- a/src/WIO/EdkBundle/Model/RouteVerifierResult.php
+++ b/src/WIO/EdkBundle/Model/RouteVerifierResult.php
@@ -11,6 +11,15 @@ use WIO\EdkBundle\Exception\RouteVerifierResultException;
 
 class RouteVerifierResult
 {
+    /** @var int */
+    const MAX_ELEVATION_CHARACTERISTICS_NUMBER = 1000; // ~ 65535 / 65
+
+    /** @var int */
+    const MAX_PATH_COORDINATES_NUMBER = 100000; // ~ 16777215 / 35
+
+    /** @var int */
+    const MAX_STATIONS_NUMBER = 1600; // ~ 65535 / 40
+
     /** @var array */
     private $verificationStatus;
 
@@ -32,6 +41,13 @@ class RouteVerifierResult
     /** @var Coordinates */
     private $pathEnd;
 
+    /**
+     * Construct
+     *
+     * @param array $body body
+     *
+     * @throws RouteVerifierResultException
+     */
     public function __construct(array $body)
     {
         $statusItemsByValues = [
@@ -59,6 +75,9 @@ class RouteVerifierResult
                                     'elevation' => new LocalAssert\Type('number'),
                                 ]),
                             ]),
+                            new Assert\Count([
+                                'max' => self::MAX_ELEVATION_CHARACTERISTICS_NUMBER,
+                            ]),
                         ],
                         'pathCoordinates' => [
                             new Assert\Type('array'),
@@ -70,6 +89,9 @@ class RouteVerifierResult
                                         'longitude' => new LocalAssert\Type('number'),
                                     ],
                                 ]),
+                            ]),
+                            new Assert\Count([
+                                'max' => self::MAX_PATH_COORDINATES_NUMBER,
                             ]),
                         ],
                         'pathEnd' => new Assert\Collection([
@@ -97,6 +119,9 @@ class RouteVerifierResult
                                         'longitude' => new LocalAssert\Type('number'),
                                     ],
                                 ]),
+                            ]),
+                            new Assert\Count([
+                                'max' => self::MAX_STATIONS_NUMBER,
                             ]),
                         ],
                     ],
@@ -140,12 +165,14 @@ class RouteVerifierResult
             return in_array($key, $statusKeys);
         }, ARRAY_FILTER_USE_KEY);
         $this->verificationLogs = $body['verificationStatus']['logs'];
-        $this->elevationCharacteristic = $body['routeCharacteristics']['elevationCharacteristics'];
+        $this->elevationCharacteristic = array_map(function ($data) {
+            return ['distance' => round($data['distance'], 20), 'elevation' => round($data['elevation'], 20)];
+        }, $body['routeCharacteristics']['elevationCharacteristics']);
         $this->pathCoordinates = array_map(function ($data) {
-            return new Coordinates($data['latitude'], $data['longitude']);
+            return new Coordinates(round($data['latitude'], 10), round($data['longitude'], 10));
         }, $body['routeCharacteristics']['pathCoordinates']);
         $this->stations = array_map(function ($data) {
-            return new IndexedCoordinates($data['index'], $data['latitude'], $data['longitude']);
+            return new IndexedCoordinates($data['index'], round($data['latitude'], 10), round($data['longitude'], 10));
         }, $body['routeCharacteristics']['stations']);
         $pathStart = $body['routeCharacteristics']['pathStart'];
         $this->pathStart = new Coordinates($pathStart['latitude'], $pathStart['longitude']);

--- a/src/WIO/EdkBundle/Tests/Model/CoordinatesTest.php
+++ b/src/WIO/EdkBundle/Tests/Model/CoordinatesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WIO\EdkBundle\Model\Coordinates;
+
+final class CoordinatesTest extends TestCase
+{
+    public function testCreatingCoordinatesPairUsingConstructorAndGetItUsingGetters()
+    {
+        $coordinates = new Coordinates(-2, 5.3);
+        $this->assertEquals(-2, $coordinates->getLatitude());
+        $this->assertEquals(5.3, $coordinates->getLongitude());
+    }
+
+    public function testCreatingCoordinatesPairUsingStaticMethodAndGetItUsingJsonMethod()
+    {
+        $coordinates = Coordinates::createFromDb([-2, 5.3]);
+        $this->assertEquals([-2, 5.3], $coordinates->jsonSerialize());
+    }
+
+    public function testEmptyListOfCoordinatesPairsToCreateAverageCoordinates()
+    {
+        $avgCoordinates = Coordinates::createAvg();
+        $this->assertEquals([0, 0], $avgCoordinates->jsonSerialize());
+    }
+
+    public function testOneElementListOfCoordinatesPairsToCreateAverageCoordinates()
+    {
+        $avgCoordinates = Coordinates::createAvg(
+            new Coordinates(3.5, 8)
+        );
+        $this->assertEquals([3.5, 8], $avgCoordinates->jsonSerialize());
+    }
+
+    public function testTwoElementListOfCoordinatesPairsToCreateAverageCoordinates()
+    {
+        $avgCoordinates = Coordinates::createAvg(
+            new Coordinates(-2, 3.3),
+            new Coordinates(4, -6.6)
+        );
+        $this->assertEquals([1, -1.65], $avgCoordinates->jsonSerialize());
+    }
+
+    public function testFourElementListOfCoordinatesPairsToCreateAverageCoordinates()
+    {
+        $avgCoordinates = Coordinates::createAvg(
+            new Coordinates(4, 4),
+            new Coordinates(-2, -2),
+            new Coordinates(-3, 4),
+            new Coordinates(5, -2)
+        );
+        $this->assertEquals([1, 1], $avgCoordinates->jsonSerialize());
+    }
+}

--- a/src/WIO/EdkBundle/Tests/Model/IndexedCoordinatesTest.php
+++ b/src/WIO/EdkBundle/Tests/Model/IndexedCoordinatesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WIO\EdkBundle\Model\IndexedCoordinates;
+
+final class IndexedCoordinatesTest extends TestCase
+{
+    public function testCreatingCoordinatesPairUsingConstructorAndGetItUsingGetters()
+    {
+        $coordinates = new IndexedCoordinates(3, -2, 5.3);
+        $this->assertEquals(3, $coordinates->getIndex());
+        $this->assertEquals(-2, $coordinates->getLatitude());
+        $this->assertEquals(5.3, $coordinates->getLongitude());
+    }
+
+    public function testCreatingCoordinatesPairUsingStaticMethodAndGetItUsingJsonMethod()
+    {
+        $coordinates = IndexedCoordinates::createFromDb([3, -2, 5.3]);
+        $this->assertEquals([3, -2, 5.3], $coordinates->jsonSerialize());
+    }
+}

--- a/src/WIO/EdkBundle/Tests/Model/RouteVerifierResultTest.php
+++ b/src/WIO/EdkBundle/Tests/Model/RouteVerifierResultTest.php
@@ -17,6 +17,19 @@ final class RouteVerifierResultTest extends TestCase
                 ['distance' => 8, 'elevation' => 0.8],
                 ['distance' => 10, 'elevation' => -0.1],
             ],
+            'pathCoordinates' => [
+                ['latitude' => 2.2, 'longitude' => 4.4],
+                ['latitude' => 4.4, 'longitude' => -1.1],
+                ['latitude' => 5, 'longitude' => 0],
+                ['latitude' => -1.1, 'longitude' => 2.2],
+            ],
+            'pathEnd' => ['latitude' => -1.1, 'longitude' => 2.2],
+            'pathStart' => ['latitude' => 2.2, 'longitude' => 4.4],
+            'stations' => [
+                ['index' => 1, 'latitude' => 2.2, 'longitude' => 4.4],
+                ['index' => 2, 'latitude' => 4.4, 'longitude' => -1.1],
+                ['index' => 3, 'latitude' => -1.1, 'longitude' => 2.2],
+            ],
         ], $patch);
     }
 
@@ -34,6 +47,16 @@ final class RouteVerifierResultTest extends TestCase
             'stationsOnPath' => ['valid' => true],
             'stationsOrder' => ['valid' => true],
         ], $patch);
+    }
+
+    private function dataAsserts(RouteVerifierResult $result, array $routeCharacteristics, array $verificationStatus)
+    {
+        $this->assertEquals($routeCharacteristics['elevationCharacteristics'], $result->getElevationCharacteristic());
+        $this->assertEquals($routeCharacteristics['pathCoordinates'], $result->getPathCoordinates());
+        $this->assertEquals($routeCharacteristics['stations'], $result->getStations());
+        $this->assertEquals($verificationStatus, array_merge($result->getVerificationStatus(), [
+            'logs' => $result->getVerificationLogs(),
+        ]));
     }
 
     public function testEmptyInput()
@@ -177,12 +200,7 @@ final class RouteVerifierResultTest extends TestCase
             'verificationStatus' => $verificationStatus,
         ]);
         $this->assertTrue($result->isValid());
-        $this->assertEquals(
-            $routeCharacteristics['elevationCharacteristics'], $result->getElevationCharacteristic()
-        );
-        $this->assertEquals($verificationStatus, array_merge($result->getVerificationStatus(), [
-            'logs' => $result->getVerificationLogs(),
-        ]));
+        $this->dataAsserts($result, $routeCharacteristics, $verificationStatus);
     }
 
     public function testCorrectInvalidInput()
@@ -203,12 +221,7 @@ final class RouteVerifierResultTest extends TestCase
             'verificationStatus' => $verificationStatus,
         ]);
         $this->assertFalse($result->isValid());
-        $this->assertEquals(
-            $routeCharacteristics['elevationCharacteristics'], $result->getElevationCharacteristic()
-        );
-        $this->assertEquals($verificationStatus, array_merge($result->getVerificationStatus(), [
-            'logs' => $result->getVerificationLogs(),
-        ]));
+        $this->dataAsserts($result, $routeCharacteristics, $verificationStatus);
     }
 
     public function testCorrectValidInputWithEmptyElevationCharacteristic()
@@ -223,12 +236,7 @@ final class RouteVerifierResultTest extends TestCase
             'verificationStatus' => $verificationStatus,
         ]);
         $this->assertTrue($result->isValid());
-        $this->assertEquals(
-            $routeCharacteristics['elevationCharacteristics'], $result->getElevationCharacteristic()
-        );
-        $this->assertEquals($verificationStatus, array_merge($result->getVerificationStatus(), [
-            'logs' => $result->getVerificationLogs(),
-        ]));
+        $this->dataAsserts($result, $routeCharacteristics, $verificationStatus);
     }
 
     public function testCorrectValidInputWithUnexpectedParamsInStatusGroups()
@@ -245,12 +253,7 @@ final class RouteVerifierResultTest extends TestCase
             'verificationStatus' => $verificationStatus,
         ]);
         $this->assertTrue($result->isValid());
-        $this->assertEquals(
-            $routeCharacteristics['elevationCharacteristics'], $result->getElevationCharacteristic()
-        );
-        $this->assertEquals($verificationStatus, array_merge($result->getVerificationStatus(), [
-            'logs' => $result->getVerificationLogs(),
-        ]));
+        $this->dataAsserts($result, $routeCharacteristics, $verificationStatus);
     }
 
     public function testCorrectValidInput()
@@ -263,11 +266,6 @@ final class RouteVerifierResultTest extends TestCase
             'verificationStatus' => $verificationStatus,
         ]);
         $this->assertTrue($result->isValid());
-        $this->assertEquals(
-            $routeCharacteristics['elevationCharacteristics'], $result->getElevationCharacteristic()
-        );
-        $this->assertEquals($verificationStatus, array_merge($result->getVerificationStatus(), [
-            'logs' => $result->getVerificationLogs(),
-        ]));
+        $this->dataAsserts($result, $routeCharacteristics, $verificationStatus);
     }
 }

--- a/src/WIO/EdkBundle/Tests/Model/RouteVerifierResultTest.php
+++ b/src/WIO/EdkBundle/Tests/Model/RouteVerifierResultTest.php
@@ -82,7 +82,9 @@ final class RouteVerifierResultTest extends TestCase
     private function assertEqualsCoordinatesList(array $expectedList, array $actualList, $name)
     {
         foreach ($actualList as $index => $actual) {
-            $this->assertEqualsCoordinates($expectedList[$index], $actual, sprintf('%d element of %s', $index, $name));
+            $this->assertEqualsCoordinates(
+                $expectedList[$index], $actual, sprintf('array element %d in %s', $index, $name)
+            );
         }
     }
 
@@ -562,6 +564,8 @@ final class RouteVerifierResultTest extends TestCase
                     ['latitude' => 2.736512437489, 'longitude' => -23.3847129638],
                     ['latitude' => 37.983, 'longitude' => -9.117324891264],
                 ],
+                'pathEnd' => ['latitude' => 37.98384756789, 'longitude' => -9.117324891264],
+                'pathStart' => ['latitude' => 2.736512437489, 'longitude' => -23.384712963834],
                 'stations' => [
                     ['index' => 1, 'latitude' => 9.6235, 'longitude' => 76.97840768271],
                     ['index' => 2, 'latitude' => -8.826194768234, 'longitude' => -23.8172],
@@ -579,6 +583,8 @@ final class RouteVerifierResultTest extends TestCase
                 ['latitude' => 2.7365124375, 'longitude' => -23.3847129638],
                 ['latitude' => 37.983, 'longitude' => -9.1173248913],
             ],
+            'pathEnd' => ['latitude' => 37.9838475679, 'longitude' => -9.1173248913],
+            'pathStart' => ['latitude' => 2.7365124375, 'longitude' => -23.3847129638],
             'stations' => [
                 ['index' => 1, 'latitude' => 9.6235, 'longitude' => 76.9784076827],
                 ['index' => 2, 'latitude' => -8.8261947682, 'longitude' => -23.8172],

--- a/src/WIO/EdkBundle/Tests/Model/RouteVerifierResultTest.php
+++ b/src/WIO/EdkBundle/Tests/Model/RouteVerifierResultTest.php
@@ -499,7 +499,7 @@ final class RouteVerifierResultTest extends TestCase
         ]);
         $this->assertTrue($result->isValid());
         $jsonLength = strlen(json_encode($result->getPathCoordinates()));
-        $this->assertEquals(3100001, $jsonLength);
+        $this->assertEquals(2900001, $jsonLength);
         $this->assertLessThanOrEqual(self::MAX_MEDIUMTEXT_FIELD_LENGTH, $jsonLength);
     }
 
@@ -516,7 +516,7 @@ final class RouteVerifierResultTest extends TestCase
         ]);
         $this->assertTrue($result->isValid());
         $jsonLength = strlen(json_encode($result->getStations()));
-        $this->assertEquals(54401, $jsonLength);
+        $this->assertEquals(57601, $jsonLength);
         $this->assertLessThanOrEqual(self::MAX_TEXT_FIELD_LENGTH, $jsonLength);
     }
 
@@ -580,14 +580,14 @@ final class RouteVerifierResultTest extends TestCase
                 ['distance' => 27.9384615237465217486, 'elevation' => 53.93846576873612798376],
             ],
             'pathCoordinates' => [
-                ['latitude' => 2.7365124375, 'longitude' => -23.3847129638],
-                ['latitude' => 37.983, 'longitude' => -9.1173248913],
+                ['latitude' => 2.736512437, 'longitude' => -23.384712964],
+                ['latitude' => 37.983, 'longitude' => -9.117324891],
             ],
-            'pathEnd' => ['latitude' => 37.9838475679, 'longitude' => -9.1173248913],
-            'pathStart' => ['latitude' => 2.7365124375, 'longitude' => -23.3847129638],
+            'pathEnd' => ['latitude' => 37.983847568, 'longitude' => -9.117324891],
+            'pathStart' => ['latitude' => 2.736512437, 'longitude' => -23.384712964],
             'stations' => [
-                ['index' => 1, 'latitude' => 9.6235, 'longitude' => 76.9784076827],
-                ['index' => 2, 'latitude' => -8.8261947682, 'longitude' => -23.8172],
+                ['index' => 1, 'latitude' => 9.6235, 'longitude' => 76.978407683],
+                ['index' => 2, 'latitude' => -8.826194768, 'longitude' => -23.8172],
             ],
         ]), $verificationStatus);
     }


### PR DESCRIPTION
There is LONGTEXT field as `pathCoordinates` because tested KML file caused generating too many points for JSON in TEXT field. I also reduced JSON length by replacing coordinates objects by arrays (latitude = 0, longitude = 1 etc.) but there is no limit of `pathCoordinates` array length so in theory very long list can causes DB error during saving route. Should I try to estimate what number of points can be consider "safe" and add maximum array elements validation?