### PR TITLE
#184 Route create/edit fix

### DIFF
--- a/app/DoctrineMigrations/Version20200314010912.php
+++ b/app/DoctrineMigrations/Version20200314010912.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200314010912 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `cantiga_areas`
+            CHANGE `visiblePublicly` `visiblePublicly` int(11) NOT NULL DEFAULT 0');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `cantiga_areas`
+            CHANGE `visiblePublicly` `visiblePublicly` int(11) NOT NULL');
+    }
+}

--- a/src/WIO/EdkBundle/Controller/RouteController.php
+++ b/src/WIO/EdkBundle/Controller/RouteController.php
@@ -170,7 +170,6 @@ class RouteController extends WorkspaceController
 		$this->crudInfo->setInfoPage('edk_route_verify');
 		$action = new InsertAction($this->crudInfo, $entity, EdkRouteForm::class, [
 			'areaRepository' => $this->findAreaRepository($membership),
-            'isPlaceManager' => $this->isGranted('PLACE_MANAGER'),
             'mode' => EdkRouteForm::ADD,
 		]);
 		$action->slug($this->getSlug());
@@ -186,7 +185,6 @@ class RouteController extends WorkspaceController
         $this->crudInfo->setInfoPage('edk_route_verify');
 		$action = new EditAction($this->crudInfo, EdkRouteForm::class, [
 			'areaRepository' => $this->findAreaRepository($membership),
-            'isPlaceManager' => $this->isGranted('PLACE_MANAGER'),
             'mode' => EdkRouteForm::EDIT,
 		]);
 		$action->slug($this->getSlug());

--- a/src/WIO/EdkBundle/Entity/EdkRoute.php
+++ b/src/WIO/EdkBundle/Entity/EdkRoute.php
@@ -266,8 +266,6 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 	
 	public static function loadValidatorMetadata(ClassMetadata $metadata)
 	{
-		$metadata->addConstraint(new Callback('validate'));
-
 		$metadata->addPropertyConstraint('name', new NotBlank());
 		$metadata->addPropertyConstraint('name', new Length(array('min' => 2, 'max' => 50)));
         $metadata->addPropertyConstraint('routePatron', new Length(array('min' => 2, 'max' => 50)));
@@ -282,52 +280,6 @@ class EdkRoute implements IdentifiableInterface, InsertableEntityInterface, Edit
 		$metadata->addPropertyConstraint('routeCourse', new NotBlank());
 		$metadata->addPropertyConstraint('routeCourse', new Length(array('min' => 2, 'max' => 500)));
 		$metadata->addPropertyConstraint('routeObstacles', new Length(array('min' => 0, 'max' => 100)));
-	}
-	
-	public function validate(ExecutionContextInterface $context)
-	{
-//		if ($this->routeType == self::TYPE_FULL) {
-//			if ($this->routeLength < 30) {
-//				$context->buildViolation('RouteLengthGreaterThan30Km')
-//					->atPath('routeLength')
-//					->addViolation();
-//				return false;
-//			}
-//			if ($this->routeLength >= 30 && $this->routeLength < 40) {
-//				if ($this->routeAscent < 500) {
-//					$context->buildViolation('Routes30To40KmMustHaveEnoughAscent')
-//						->atPath('routeAscent')
-//						->addViolation();
-//					return false;
-//				}
-//			}
-//		} elseif ($this->routeType == self::TYPE_INSPIRED) {
-//			if ($this->routeLength < 30) {
-//				$context->buildViolation('RouteLengthGreaterThan20Km')
-//					->atPath('routeLength')
-//					->addViolation();
-//				return false;
-//			}
-//			if ($this->routeAscent < 0) {
-//				$context->buildViolation('NegativeAscentInvalid')
-//					->atPath('routeAscent')
-//					->addViolation();
-//				return false;
-//			}
-//		}
-        if ($this->routeLength < 30) {
-            $context->buildViolation('RouteLengthGreaterThan30Km')
-                ->atPath('routeLength')
-                ->addViolation();
-            return false;
-        }
-        if ($this->routeAscent < 0) {
-            $context->buildViolation('NegativeAscentInvalid')
-                ->atPath('routeAscent')
-                ->addViolation();
-            return false;
-        }
-		return true;
 	}
 	
 	public function getId()

--- a/src/WIO/EdkBundle/Form/EdkRouteForm.php
+++ b/src/WIO/EdkBundle/Form/EdkRouteForm.php
@@ -38,7 +38,7 @@ class EdkRouteForm extends AbstractType
 
 	public function configureOptions(OptionsResolver $resolver)
 	{
-		$resolver->setDefined(['mode', 'areaRepository', 'isPlaceManager']);
+		$resolver->setDefined(['mode', 'areaRepository']);
 		$resolver->setRequired(['mode']);
 		
 		$resolver->setDefaults(array(
@@ -48,22 +48,11 @@ class EdkRouteForm extends AbstractType
 	
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
-	    $isPlaceManager = (bool) $options['isPlaceManager'];
 		if (!empty($options['areaRepository'])) {
 			$builder->add('area', ChoiceType::class, ['label' => 'Area', 'choices' => $options['areaRepository']->getFormChoices()]);
 			$builder->get('area')->addModelTransformer(new EntityTransformer($options['areaRepository']));
 		}
 
-		if ($isPlaceManager) {
-			$builder->add('routeType', ChoiceType::class, [
-				'choices' => [
-					'UndefinedRoute' => EdkRoute::TYPE_UNDEFINED,
-					'FullRoute' => EdkRoute::TYPE_FULL,
-					'RouteInspiredByEWC' => EdkRoute::TYPE_INSPIRED,
-				],
-				'label' => 'Route type',
-			]);
-		}
 		$builder
 			->add('name', TextType::class, array('label' => 'Route name','attr' => array('help_text' => 'Name helptext','placeholder' => 'Name placeholder')))
             ->add('routePatron', TextType::class, array('label' => 'Route patron','required' => false,'attr' => array('placeholder' => 'Patron placeholder')))
@@ -82,19 +71,6 @@ class EdkRouteForm extends AbstractType
             ->add('routeToDetails', TextType::class,
                 array('label' => 'Route end details', 'required' => false, 'attr' => array('help_text' => '(settlement details)','placeholder' => 'From Details placeholder'))
             )
-        ;
-		if ($isPlaceManager) {
-			$builder
-				->add('routeLength', IntegerType::class, [
-					'label' => 'Route length (km)',
-				])
-				->add('routeAscent', IntegerType::class, [
-					'attr' => ['help_text' => 'RouteAscentInfoText'],
-					'label' => 'Route ascent (m)',
-				])
-			;
-		}
-		$builder
 			->add('routeObstacles', TextType::class, 
 				array('label' => 'Additional obstacles', 'required' => false)
 			)

--- a/src/WIO/EdkBundle/Resources/translations/edk.pl.php
+++ b/src/WIO/EdkBundle/Resources/translations/edk.pl.php
@@ -22,18 +22,15 @@ return [
 	'Files' => 'Pliki',
 	
 	'Ascent' => 'Suma podejść',
-	'Length' => 'Długość',
 	'Beginning' => 'Początek',
 	'Ending' => 'Koniec',
 	'Name' => 'Nazwa',
 	'Route name' => 'Nazwa trasy',
-	'Route type' => 'Rodzaj trasy',
 	'Route patron' => 'Patron',
 	'Route color' => 'Kolor',
 	'Route author' => 'Autor',
 	'Comments' => 'Komentarzy',
 	'Area' => 'Rejon',
-	'Created at' => 'Utworzono',
 	'Updated at' => 'Zmodyfikowano',
 	'Approved at' => 'Zatwierdzono',
 	'Approved' => 'Zatwierdzona',
@@ -153,7 +150,6 @@ return [
 	'Registration via external website' => 'Rejestracja przez zewnętrzną stronę WWW',
 	
 	'Participants' => 'Uczestnicy',
-	'External participants' => 'Niezarejestrowani',
 	'Current number of participants' => 'Obecnie zarejestrowanych przez stronę EDK',
 	'Participants registered externally' => 'Uczestnicy niezarejestrowani',
 	'Beginning of registration' => 'Początek rejestracji',
@@ -185,7 +181,6 @@ return [
 	'MsgStatusClosed' => 'Zamknięta',
 	
 	'Message: 0' => 'Wiadomość: 0',
-	'E-mail' => 'E-mail',
 	'Phone number' => 'Numer telefonu',
 	'Duplicate' => 'Duplikat',
 	'Subject' => 'Temat',
@@ -200,7 +195,6 @@ return [
 	'MsgTransitionTakeMessage' => 'Weź wiadomość',
 	'MsgTransitionClose' => 'Zamknij wiadomość',
 	'MsgTransitionComplete' => 'Zakończ odpowiadanie',
-	'MsgTransitionReset' => 'Zresetuj stan',
 	'MsgTransitionUndo' => 'Cofnij się do fazy odpowiadania',
 	'MsgTransitionReset' => 'Zresetuj stan',
 	
@@ -312,5 +306,4 @@ return [
 
 	'Participants count' => 'Liczba uczestników',
 	'Disable chatbox' => 'W przypadku wątpliwości co do komentarzy skontaktuj się z zespołem tras.'
-
 ];

--- a/src/WIO/EdkBundle/Resources/translations/validators.en.php
+++ b/src/WIO/EdkBundle/Resources/translations/validators.en.php
@@ -19,11 +19,6 @@ return [
 	'MinimumParticipantLimitErrMsg' => 'Minimum value is 10 participants.',
 	'InvalidRegistrationTypeErrMsg' => 'Invalid registration type.',
 
-	'RouteLengthGreaterThan30Km' => 'Route length should be equal or greater than 30 km.',
-	'Routes30To40KmMustHaveEnoughAscent' => 'Routes from 30 up to 40 km long should have proper ascent.',
-	'RouteLengthGreaterThan20Km' => 'Route length should be equal or greater than 20 km.',
-	'NegativeAscentInvalid' => 'Value of ascent couldn\'t be negative.',
-	
 	'MaxPeoplePerRecordRequired' => 'This field is required with this registration type - please enter a number from 1 to 10.',
 	'FieldRequiredErrMsg' => 'This field is required with this registration type.',
 ];

--- a/src/WIO/EdkBundle/Resources/translations/validators.pl.php
+++ b/src/WIO/EdkBundle/Resources/translations/validators.pl.php
@@ -19,12 +19,6 @@ return [
 	'MinimumParticipantLimitErrMsg' => 'Minimalna wartość to 10 uczestników.',
 	'InvalidRegistrationTypeErrMsg' => 'Nieprawidłowy rodzaj rejestracji.',
 
-	'RouteLengthGreaterThan30Km' => 'Długość trasy powinna być równa lub większa niż 30 km.',
-	'Routes30To40KmMustHaveEnoughAscent' => 'Trasy o długości od 30 do 40 km powinny mieć odpowiednią sumę podejść.',
-	'RouteLengthGreaterThan20Km' => 'Długość trasy powinna być równa lub większa niż 20 km.',
-    'RouteLengthGreaterThan30Km' => 'Długość trasy powinna być równa lub większa niż 30 km.',
-	'NegativeAscentInvalid' => 'Wartość sumy podejść nie może być ujemna.',
-	
 	'MaxPeoplePerRecordRequired' => 'To pole jest wymagane przy tym typie rejestracji - podaj liczbę z przedziału 1-10.',
 	'FieldRequiredErrMsg' => 'To pole jest wymagane przy tym typie rejestracji.',
 ];


### PR DESCRIPTION
Thanks to @quchasz I found a problem with adding/editing route by someone else than route manager (problem occured after route's `validate` method's change earlier this year). According @quchasz's suggestions I removed `routeType`, `routeLength` and `routeAscent` totally from `EdkRouteForm` as well as `routeLength`'s validation (@qooban: route length's validation is already supported by verifier which treats length lower than 30km as invalid, right?) relying on verifier.